### PR TITLE
fix: Upload only artifacts from this project to the NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Aave Protocol V3 periphery smart contracts",
   "files": [
     "contracts",
-    "artifacts"
+    "artifacts/contracts"
   ],
   "scripts": {
     "run-env": "npm i && tail -f /dev/null",


### PR DESCRIPTION
Publish only related artifacts of @aave/periphery-v3 without including external dependencies