### PR TITLE
feat: add Collector implementation and controller

### DIFF
--- a/contracts/treasury/Collector.sol
+++ b/contracts/treasury/Collector.sol
@@ -7,7 +7,8 @@ import {ICollector} from './interfaces/ICollector.sol';
 
 /**
  * @title Collector
- * @notice Stores the fees collected by the protocol and allows the fund administrator to approve or transfer the collected ERC20 tokens.
+ * @notice Stores the fees collected by the protocol and allows the fund administrator
+ *         to approve or transfer the collected ERC20 tokens.
  * @author Aave
  **/
 contract Collector is ICollector, VersionedInitializable {

--- a/contracts/treasury/Collector.sol
+++ b/contracts/treasury/Collector.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.10;
+
+import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import {ICollector} from './interfaces/ICollector.sol';
+import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
+
+/**
+ * @title Collector
+ * @notice Stores the fees collected by the protocol and allows the fund administrator to approve or transfer the collected ERC20 tokens.
+ * @author Aave
+ **/
+contract Collector is ICollector, VersionedInitializable {
+  event NewFundsAdmin(address indexed fundsAdmin);
+
+  address internal _fundsAdmin;
+
+  uint256 public constant REVISION = 1;
+
+  /// @inheritdoc ICollector
+  function initialize(address reserveController) external initializer {
+    _setFundsAdmin(reserveController);
+  }
+
+  modifier onlyFundsAdmin() {
+    require(msg.sender == _fundsAdmin, 'ONLY_BY_FUNDS_ADMIN');
+    _;
+  }
+
+  /// @inheritdoc VersionedInitializable
+  function getRevision() internal pure override returns (uint256) {
+    return REVISION;
+  }
+
+  /// @inheritdoc ICollector
+  function getFundsAdmin() external view returns (address) {
+    return _fundsAdmin;
+  }
+
+  /// @inheritdoc ICollector
+  function approve(
+    IERC20 token,
+    address recipient,
+    uint256 amount
+  ) external onlyFundsAdmin {
+    token.approve(recipient, amount);
+  }
+
+  /// @inheritdoc ICollector
+  function transfer(
+    IERC20 token,
+    address recipient,
+    uint256 amount
+  ) external onlyFundsAdmin {
+    token.transfer(recipient, amount);
+  }
+
+  /// @inheritdoc ICollector
+  function setFundsAdmin(address admin) external onlyFundsAdmin {
+    _setFundsAdmin(admin);
+  }
+
+  /**
+   * @dev Transfer the ownership of the funds administrator role.
+   * @param admin The address of the new funds administrator
+   */
+  function _setFundsAdmin(address admin) internal {
+    _fundsAdmin = admin;
+    emit NewFundsAdmin(admin);
+  }
+}

--- a/contracts/treasury/Collector.sol
+++ b/contracts/treasury/Collector.sol
@@ -12,20 +12,30 @@ import {ICollector} from './interfaces/ICollector.sol';
  * @author Aave
  **/
 contract Collector is VersionedInitializable, ICollector {
+  /**
+   * @dev Emitted during the transfer of ownership of the funds administrator address
+   * @param from The new funds administrator address
+   **/
   event NewFundsAdmin(address indexed fundsAdmin);
 
   address internal _fundsAdmin;
 
   uint256 public constant REVISION = 1;
 
-  /// @inheritdoc ICollector
-  function initialize(address reserveController) external initializer {
-    _setFundsAdmin(reserveController);
-  }
-
+  /**
+   * @dev Allow only the funds administrator address to call functions marked by this modifier
+   */
   modifier onlyFundsAdmin() {
     require(msg.sender == _fundsAdmin, 'ONLY_BY_FUNDS_ADMIN');
     _;
+  }
+
+  /**
+   * @dev Initialize the transparent proxy with the admin of the Collector
+   * @param reserveController The address of the admin that controls Collector
+   */
+  function initialize(address reserveController) external initializer {
+    _setFundsAdmin(reserveController);
   }
 
   /// @inheritdoc VersionedInitializable

--- a/contracts/treasury/Collector.sol
+++ b/contracts/treasury/Collector.sol
@@ -9,17 +9,14 @@ import {ICollector} from './interfaces/ICollector.sol';
  * @title Collector
  * @notice Stores the fees collected by the protocol and allows the fund administrator
  *         to approve or transfer the collected ERC20 tokens.
+ * @dev Implementation contract that must be initialized using transparent proxy pattern.
  * @author Aave
  **/
 contract Collector is VersionedInitializable, ICollector {
-  /**
-   * @dev Emitted during the transfer of ownership of the funds administrator address
-   * @param from The new funds administrator address
-   **/
-  event NewFundsAdmin(address indexed fundsAdmin);
-
+  // Store the current funds administrator address
   address internal _fundsAdmin;
 
+  // Revision version of this implementation contract
   uint256 public constant REVISION = 1;
 
   /**

--- a/contracts/treasury/Collector.sol
+++ b/contracts/treasury/Collector.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity 0.8.10;
 
+import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import {ICollector} from './interfaces/ICollector.sol';
-import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
 
 /**
  * @title Collector

--- a/contracts/treasury/Collector.sol
+++ b/contracts/treasury/Collector.sol
@@ -11,7 +11,7 @@ import {ICollector} from './interfaces/ICollector.sol';
  *         to approve or transfer the collected ERC20 tokens.
  * @author Aave
  **/
-contract Collector is ICollector, VersionedInitializable {
+contract Collector is VersionedInitializable, ICollector {
   event NewFundsAdmin(address indexed fundsAdmin);
 
   address internal _fundsAdmin;

--- a/contracts/treasury/CollectorController.sol
+++ b/contracts/treasury/CollectorController.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: agpl-3.0
 pragma solidity 0.8.10;
 
+import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import {ICollector} from './interfaces/ICollector.sol';
-import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
 
 /**
  * @title CollectorController
  * @notice The CollectorController contracts allows the owner of the contract
            to approve or transfer tokens from the collector proxy contract.
-           This is needed due the usage of transparent proxy pattern.
            The admin of the Collector proxy can't be the same as the fundsAdmin address.
+           This is needed due the usage of transparent proxy pattern.
  * @author Aave
  **/
 contract CollectorController is Ownable {

--- a/contracts/treasury/CollectorController.sol
+++ b/contracts/treasury/CollectorController.sol
@@ -7,12 +7,10 @@ import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contrac
 
 /**
  * @title CollectorController
- * @notice The CollectorController contracts allows the owner
-           of the contract to approve or transfer tokens from
-           the collector proxy contract. This is needed because of
-           the transparent proxy pattern. The admin
-           of the AaveCollector proxy can't be the same as
-           the fundsAdmin address.
+ * @notice The CollectorController contracts allows the owner of the contract
+           to approve or transfer tokens from the collector proxy contract.
+           This is needed due the usage of transparent proxy pattern.
+           The admin of the Collector proxy can't be the same as the fundsAdmin address.
  * @author Aave
  **/
 contract CollectorController is Ownable {

--- a/contracts/treasury/CollectorController.sol
+++ b/contracts/treasury/CollectorController.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.10;
+
+import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+import {ICollector} from './interfaces/ICollector.sol';
+import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
+
+/**
+ * @title CollectorController
+ * @notice The CollectorController contracts allows the owner
+           of the contract to approve or transfer tokens from
+           the collector proxy contract. This is needed because of
+           the transparent proxy pattern. The admin
+           of the AaveCollector proxy can't be the same as
+           the fundsAdmin address.
+ * @author Aave
+ **/
+contract CollectorController is Ownable {
+  ICollector public immutable COLLECTOR;
+
+  /**
+   * @dev Constructor setups the ownership of the contract and the collector proxy
+   * @param owner The address of the owner of the CollectorController
+   * @param collectorProxy The address of the Collector transparent proxy
+   */
+  constructor(address owner, address collectorProxy) {
+    transferOwnership(owner);
+    COLLECTOR = ICollector(collectorProxy);
+  }
+
+  /**
+   * @dev Transfer an amount of tokens to the recipient.
+   * @param token The address of the asset
+   * @param recipient The address of the entity to transfer the tokens.
+   * @param amount The amount to be transferred.
+   */
+  function approve(
+    IERC20 token,
+    address recipient,
+    uint256 amount
+  ) external onlyOwner {
+    COLLECTOR.approve(token, recipient, amount);
+  }
+
+  /**
+   * @dev Transfer an amount of tokens to the recipient.
+   * @param token The address of the asset
+   * @param recipient The address of the entity to transfer the tokens.
+   * @param amount The amount to be transferred.
+   */
+  function transfer(
+    IERC20 token,
+    address recipient,
+    uint256 amount
+  ) external onlyOwner {
+    COLLECTOR.transfer(token, recipient, amount);
+  }
+}

--- a/contracts/treasury/interfaces/ICollector.sol
+++ b/contracts/treasury/interfaces/ICollector.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.10;
+
+import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
+
+interface ICollector {
+  /**
+   * @dev Approve an amount of tokens to be pulled by the recipient.
+   * @param token The address of the asset
+   * @param recipient The address of the entity allowed to pull tokens
+   * @param amount The amount allowed to be pulled. If zero it will revoke the approval.
+   */
+  function approve(
+    IERC20 token,
+    address recipient,
+    uint256 amount
+  ) external;
+
+  /**
+   * @dev Transfer an amount of tokens to the recipient.
+   * @param token The address of the asset
+   * @param recipient The address of the entity to transfer the tokens.
+   * @param amount The amount to be transferred.
+   */
+  function transfer(
+    IERC20 token,
+    address recipient,
+    uint256 amount
+  ) external;
+
+  /**
+   * @dev Initialize the transparent proxy with the admin of the Collector
+   * @param reserveController The address of the admin that controls Collector
+   */
+  function initialize(address reserveController) external;
+
+  /**
+   * @dev Retrieve the current funds administrator
+   * @return The address of the funds administrator
+   */
+  function getFundsAdmin() external view returns (address);
+
+  /**
+   * @dev Transfer the ownership of the funds administrator role.
+   * @param admin The address of the new funds administrator
+   */
+  function setFundsAdmin(address admin) external;
+
+  /**
+   * @dev Retrieve the current implementation Revision of the proxy
+   * @return The revision version
+   */
+  function REVISION() external view returns (uint256);
+}

--- a/contracts/treasury/interfaces/ICollector.sol
+++ b/contracts/treasury/interfaces/ICollector.sol
@@ -3,7 +3,30 @@ pragma solidity 0.8.10;
 
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 
+/**
+ * @title ICollector
+ * @notice Defines the interface of the Collector contract
+ * @author Aave
+ **/
 interface ICollector {
+  /**
+   * @dev Emitted during the transfer of ownership of the funds administrator address
+   * @param fundsAdmin The new funds administrator address
+   **/
+  event NewFundsAdmin(address indexed fundsAdmin);
+
+  /**
+   * @dev Retrieve the current implementation Revision of the proxy
+   * @return The revision version
+   */
+  function REVISION() external view returns (uint256);
+
+  /**
+   * @dev Retrieve the current funds administrator
+   * @return The address of the funds administrator
+   */
+  function getFundsAdmin() external view returns (address);
+
   /**
    * @dev Approve an amount of tokens to be pulled by the recipient.
    * @param token The address of the asset
@@ -29,20 +52,9 @@ interface ICollector {
   ) external;
 
   /**
-   * @dev Retrieve the current funds administrator
-   * @return The address of the funds administrator
-   */
-  function getFundsAdmin() external view returns (address);
-
-  /**
    * @dev Transfer the ownership of the funds administrator role.
+          This function should only be callable by the current funds administrator.
    * @param admin The address of the new funds administrator
    */
   function setFundsAdmin(address admin) external;
-
-  /**
-   * @dev Retrieve the current implementation Revision of the proxy
-   * @return The revision version
-   */
-  function REVISION() external view returns (uint256);
 }

--- a/contracts/treasury/interfaces/ICollector.sol
+++ b/contracts/treasury/interfaces/ICollector.sol
@@ -29,12 +29,6 @@ interface ICollector {
   ) external;
 
   /**
-   * @dev Initialize the transparent proxy with the admin of the Collector
-   * @param reserveController The address of the admin that controls Collector
-   */
-  function initialize(address reserveController) external;
-
-  /**
    * @dev Retrieve the current funds administrator
    * @return The address of the funds administrator
    */


### PR DESCRIPTION
- Add `Collector` implementation contract and interface
- Add `CollectorController` to support same governance executor or multisign to be the owner of the proxy and the owner of the Collector admin via `CollectorController`.
