### PR TITLE
Allow Emission Manager owner of RewardsController to be mutable by current admin

### DIFF
--- a/contracts/rewards/RewardsController.sol
+++ b/contracts/rewards/RewardsController.sol
@@ -44,7 +44,8 @@ contract RewardsController is RewardsDistributor, VersionedInitializable, IRewar
   constructor(address emissionManager) RewardsDistributor(emissionManager) {}
 
   /**
-   * @dev Initialize for RewardsController where emission manager is provided at input parameter
+   * @dev Initialize for RewardsController
+   * @param emissionManager address of the EmissionManager
    **/
   function initialize(address emissionManager) external initializer {
     _setEmissionManager(emissionManager);

--- a/contracts/rewards/RewardsController.sol
+++ b/contracts/rewards/RewardsController.sol
@@ -44,9 +44,11 @@ contract RewardsController is RewardsDistributor, VersionedInitializable, IRewar
   constructor(address emissionManager) RewardsDistributor(emissionManager) {}
 
   /**
-   * @dev Empty initialize for RewardsController
+   * @dev Initialize for RewardsController where emission manager is provided at input parameter
    **/
-  function initialize() external initializer {}
+  function initialize(address emissionManager) external initializer {
+    _setEmissionManager(emissionManager);
+  }
 
   /// @inheritdoc IRewardsController
   function getClaimer(address user) external view override returns (address) {
@@ -204,8 +206,9 @@ contract RewardsController is RewardsDistributor, VersionedInitializable, IRewar
     userAssetBalances = new RewardsDataTypes.UserAssetBalance[](assets.length);
     for (uint256 i = 0; i < assets.length; i++) {
       userAssetBalances[i].asset = assets[i];
-      (userAssetBalances[i].userBalance, userAssetBalances[i].totalSupply) = IScaledBalanceToken(assets[i])
-        .getScaledUserBalanceAndSupply(user);
+      (userAssetBalances[i].userBalance, userAssetBalances[i].totalSupply) = IScaledBalanceToken(
+        assets[i]
+      ).getScaledUserBalanceAndSupply(user);
     }
     return userAssetBalances;
   }

--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -527,8 +527,8 @@ abstract contract RewardsDistributor is IRewardsDistributor {
   }
 
   /**
-   * @dev Update the EmissionManager admin to the provided address parameter
-   * @param emissionManager The address of the new emission manager
+   * @dev Updates the address of the emission manager
+   * @param emissionManager The address of the new EmissionManager
    */
   function _setEmissionManager(address emissionManager) internal {
     address previousEmissionManager = _emissionManager;

--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -531,8 +531,8 @@ abstract contract RewardsDistributor is IRewardsDistributor {
    * @param emissionManager The address of the new emission manager
    */
   function _setEmissionManager(address emissionManager) internal {
-    require(emissionManager != address(0), 'EMISSION_MANAGER_NOT_ZERO');
+    address previousEmissionManager = _emissionManager;
     _emissionManager = emissionManager;
-    emit EmissionManagerUpdated(emissionManager);
+    emit EmissionManagerUpdated(previousEmissionManager, emissionManager);
   }
 }

--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -14,7 +14,7 @@ import {RewardsDataTypes} from './libraries/RewardsDataTypes.sol';
 abstract contract RewardsDistributor is IRewardsDistributor {
   using SafeCast for uint256;
   // manager of incentives
-  address public immutable EMISSION_MANAGER;
+  address internal _emissionManager;
 
   // asset => AssetData
   mapping(address => RewardsDataTypes.AssetData) internal _assets;
@@ -29,12 +29,12 @@ abstract contract RewardsDistributor is IRewardsDistributor {
   address[] internal _assetsList;
 
   modifier onlyEmissionManager() {
-    require(msg.sender == EMISSION_MANAGER, 'ONLY_EMISSION_MANAGER');
+    require(msg.sender == _emissionManager, 'ONLY_EMISSION_MANAGER');
     _;
   }
 
   constructor(address emissionManager) {
-    EMISSION_MANAGER = emissionManager;
+    _setEmissionManager(emissionManager);
   }
 
   /// @inheritdoc IRewardsDistributor
@@ -123,7 +123,10 @@ abstract contract RewardsDistributor is IRewardsDistributor {
     override
     returns (address[] memory rewardsList, uint256[] memory unclaimedAmounts)
   {
-    RewardsDataTypes.UserAssetBalance[] memory userAssetBalances = _getUserAssetBalances(assets, user);
+    RewardsDataTypes.UserAssetBalance[] memory userAssetBalances = _getUserAssetBalances(
+      assets,
+      user
+    );
     rewardsList = new address[](_rewardsList.length);
     unclaimedAmounts = new uint256[](rewardsList.length);
 
@@ -139,11 +142,7 @@ abstract contract RewardsDistributor is IRewardsDistributor {
         if (userAssetBalances[i].userBalance == 0) {
           continue;
         }
-        unclaimedAmounts[r] += _getPendingRewards(
-          user,
-          rewardsList[r],
-          userAssetBalances[i]
-        );
+        unclaimedAmounts[r] += _getPendingRewards(user, rewardsList[r], userAssetBalances[i]);
       }
     }
     return (rewardsList, unclaimedAmounts);
@@ -180,7 +179,10 @@ abstract contract RewardsDistributor is IRewardsDistributor {
       RewardsDataTypes.AssetData storage assetConfig = _assets[asset];
       RewardsDataTypes.RewardData storage rewardConfig = _assets[asset].rewards[rewards[i]];
       uint256 decimals = assetConfig.decimals;
-      require(decimals != 0 && rewardConfig.lastUpdateTimestamp != 0, 'DISTRIBUTION_DOES_NOT_EXIST');
+      require(
+        decimals != 0 && rewardConfig.lastUpdateTimestamp != 0,
+        'DISTRIBUTION_DOES_NOT_EXIST'
+      );
 
       (uint256 newIndex, ) = _updateRewardData(
         rewardConfig,
@@ -512,5 +514,25 @@ abstract contract RewardsDistributor is IRewardsDistributor {
   /// @inheritdoc IRewardsDistributor
   function getAssetDecimals(address asset) external view returns (uint8) {
     return _assets[asset].decimals;
+  }
+
+  /// @inheritdoc IRewardsDistributor
+  function getEmissionManager() external view returns (address) {
+    return _emissionManager;
+  }
+
+  /// @inheritdoc IRewardsDistributor
+  function setEmissionManager(address emissionManager) external onlyEmissionManager {
+    _setEmissionManager(emissionManager);
+  }
+
+  /**
+   * @dev Update the EmissionManager admin to the provided address parameter
+   * @param emissionManager The address of the new emission manager
+   */
+  function _setEmissionManager(address emissionManager) internal {
+    require(emissionManager != address(0), 'EMISSION_MANAGER_NOT_ZERO');
+    _emissionManager = emissionManager;
+    emit EmissionManagerUpdated(emissionManager);
   }
 }

--- a/contracts/rewards/interfaces/IRewardsDistributor.sol
+++ b/contracts/rewards/interfaces/IRewardsDistributor.sol
@@ -47,9 +47,13 @@ interface IRewardsDistributor {
 
   /**
    * @dev Emitted when setEmissionManager is called after transfer of the EmissionManager role to a new admin
+   * @param previousEmissionManager The address of the previous emission manager that requested the update of emission manager
    * @param newEmissionManager The address of the new emission manager admin
    */
-  event EmissionManagerUpdated(address indexed newEmissionManager);
+  event EmissionManagerUpdated(
+    address indexed previousEmissionManager,
+    address indexed newEmissionManager
+  );
 
   /**
    * @dev Sets the end date for the distribution

--- a/contracts/rewards/interfaces/IRewardsDistributor.sol
+++ b/contracts/rewards/interfaces/IRewardsDistributor.sol
@@ -46,6 +46,12 @@ interface IRewardsDistributor {
   );
 
   /**
+   * @dev Emitted when setEmissionManager is called after transfer of the EmissionManager role to a new admin
+   * @param newEmissionManager The address of the new emission manager admin
+   */
+  event EmissionManagerUpdated(address indexed newEmissionManager);
+
+  /**
    * @dev Sets the end date for the distribution
    * @param asset The asset to incentivize
    * @param reward The reward token that incentives the asset
@@ -161,4 +167,16 @@ interface IRewardsDistributor {
    * @return The decimals of an underlying asset
    */
   function getAssetDecimals(address asset) external view returns (uint8);
+
+  /**
+   * @dev Returns the current EmissionManager admin address
+   * @return The address of the EmissionManager admin
+   */
+  function getEmissionManager() external view returns (address);
+
+  /**
+   * @dev Update the EmissionManager admin to a new address
+   * @param emissionManager The address of the new emission manager
+   */
+  function setEmissionManager(address emissionManager) external;
 }

--- a/contracts/rewards/interfaces/IRewardsDistributor.sol
+++ b/contracts/rewards/interfaces/IRewardsDistributor.sol
@@ -173,14 +173,14 @@ interface IRewardsDistributor {
   function getAssetDecimals(address asset) external view returns (uint8);
 
   /**
-   * @dev Returns the current EmissionManager admin address
-   * @return The address of the EmissionManager admin
+   * @dev Returns the address of the emission manager
+   * @return The address of the EmissionManager
    */
   function getEmissionManager() external view returns (address);
 
   /**
-   * @dev Update the EmissionManager admin to a new address
-   * @param emissionManager The address of the new emission manager
+   * @dev Updates the address of the emission manager
+   * @param emissionManager The address of the new EmissionManager
    */
   function setEmissionManager(address emissionManager) external;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@aave/periphery-v3",
-  "version": "1.14.0",
+  "version": "1.14.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aave/periphery-v3",
-      "version": "1.14.0",
+      "version": "1.14.1-beta.0",
       "license": "AGPLv3",
       "dependencies": {
         "@aave/core-v3": "^1.14.3-beta.0"
       },
       "devDependencies": {
-        "@aave/deploy-v3": "^1.21.1-beta.4",
+        "@aave/deploy-v3": "^1.24.1-beta.1",
         "@ethersproject/abi": "^5.1.0",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.11",
         "@nomiclabs/hardhat-etherscan": "^2.1.1",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@aave/core-v3": {
-      "version": "1.14.3-beta.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.14.3-beta.0/936803c9e795294bde88e20e0b944765c5061a262ea12d8e1fca7169fa1d9382",
-      "integrity": "sha512-W+hhOQ+t2SVnEZXMJ3ONOYNOOdmxe9Th2ajBXmkLViW3Mr8vCFjQwReYRXF9e0yWg0XDmJ20NE76aE57MGlIUg==",
+      "version": "1.15.0",
+      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.15.0/6dc24b7ad3b4140ddd65f16a0d587a9c24f72073e77f0fd2961c0f67bb38d720",
+      "integrity": "sha512-s+KnPwXpWAmUaZ3UBNzndS5DIuu9wbbwO6w1V9J5lvhA2GUhi1nL8pKXNMnm90HmOGYLT5uN+AEMvZcWUhZJdQ==",
       "license": "BUSL-1.1",
       "dependencies": {
         "@nomiclabs/hardhat-etherscan": "^2.1.7",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@aave/deploy-v3": {
-      "version": "1.21.1-beta.4",
-      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.21.1-beta.4/379cc7907d7c26584ae52205062b10390b12562c1f20ee40cb476b3f8b36f6d7",
-      "integrity": "sha512-DCTxOk7nLhIasL14xSPUb+MqCH6NroX0JkcngrCyOj975s9ggrKcfqkVcew/zpHXPyJHRoBIb0fWjBg1vXBfjQ==",
+      "version": "1.24.1-beta.1",
+      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.24.1-beta.1/88831d6b99abfbe8ce55560b852b4c790ed31151f37a77f507aeb362cfaa77ca",
+      "integrity": "sha512-xOar4GBU1rAEIrFp6rIHzhvybvc/v+tdgMI+7rPpSGs3WypTSo1kt/uVrEAIqhjyepOClXQvRR/CqdU+Q6nHZQ==",
       "dev": true,
       "license": "AGPLv3",
       "dependencies": {
@@ -91,19 +91,6 @@
       "peer": true,
       "dependencies": {
         "@aave/core-v3": "^1.9.0"
-      }
-    },
-    "node_modules/@aave/periphery-v3/node_modules/@aave/core-v3": {
-      "version": "1.14.2",
-      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.14.2/4f9d7f392d3801f1e30a8336d2eaba73a38c43f60f096871880683abccbbeac2",
-      "integrity": "sha512-3nq/WHuKpVU15yT3vemSx2gr8wzQuuzBjSailnnXbA4fMzHavZQLBTE0eLIbNFPkGAwx+jnECYZ2TuSnEqzMHQ==",
-      "dev": true,
-      "license": "BUSL-1.1",
-      "peer": true,
-      "dependencies": {
-        "@nomiclabs/hardhat-etherscan": "^2.1.7",
-        "axios-curlirize": "^1.3.7",
-        "tmp-promise": "^3.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -23114,9 +23101,9 @@
   },
   "dependencies": {
     "@aave/core-v3": {
-      "version": "1.14.3-beta.0",
-      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.14.3-beta.0/936803c9e795294bde88e20e0b944765c5061a262ea12d8e1fca7169fa1d9382",
-      "integrity": "sha512-W+hhOQ+t2SVnEZXMJ3ONOYNOOdmxe9Th2ajBXmkLViW3Mr8vCFjQwReYRXF9e0yWg0XDmJ20NE76aE57MGlIUg==",
+      "version": "1.15.0",
+      "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.15.0/6dc24b7ad3b4140ddd65f16a0d587a9c24f72073e77f0fd2961c0f67bb38d720",
+      "integrity": "sha512-s+KnPwXpWAmUaZ3UBNzndS5DIuu9wbbwO6w1V9J5lvhA2GUhi1nL8pKXNMnm90HmOGYLT5uN+AEMvZcWUhZJdQ==",
       "requires": {
         "@nomiclabs/hardhat-etherscan": "^2.1.7",
         "axios-curlirize": "^1.3.7",
@@ -23124,9 +23111,9 @@
       }
     },
     "@aave/deploy-v3": {
-      "version": "1.21.1-beta.4",
-      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.21.1-beta.4/379cc7907d7c26584ae52205062b10390b12562c1f20ee40cb476b3f8b36f6d7",
-      "integrity": "sha512-DCTxOk7nLhIasL14xSPUb+MqCH6NroX0JkcngrCyOj975s9ggrKcfqkVcew/zpHXPyJHRoBIb0fWjBg1vXBfjQ==",
+      "version": "1.24.1-beta.1",
+      "resolved": "https://npm.pkg.github.com/download/@aave/deploy-v3/1.24.1-beta.1/88831d6b99abfbe8ce55560b852b4c790ed31151f37a77f507aeb362cfaa77ca",
+      "integrity": "sha512-xOar4GBU1rAEIrFp6rIHzhvybvc/v+tdgMI+7rPpSGs3WypTSo1kt/uVrEAIqhjyepOClXQvRR/CqdU+Q6nHZQ==",
       "dev": true,
       "requires": {
         "defender-relay-client": "^1.11.1"
@@ -23140,20 +23127,6 @@
       "peer": true,
       "requires": {
         "@aave/core-v3": "^1.9.0"
-      },
-      "dependencies": {
-        "@aave/core-v3": {
-          "version": "1.14.2",
-          "resolved": "https://npm.pkg.github.com/download/@aave/core-v3/1.14.2/4f9d7f392d3801f1e30a8336d2eaba73a38c43f60f096871880683abccbbeac2",
-          "integrity": "sha512-3nq/WHuKpVU15yT3vemSx2gr8wzQuuzBjSailnnXbA4fMzHavZQLBTE0eLIbNFPkGAwx+jnECYZ2TuSnEqzMHQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@nomiclabs/hardhat-etherscan": "^2.1.7",
-            "axios-curlirize": "^1.3.7",
-            "tmp-promise": "^3.0.2"
-          }
-        }
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aave/periphery-v3",
-  "version": "1.14.0",
+  "version": "1.14.1-beta.0",
   "description": "Aave Protocol V3 periphery smart contracts",
   "files": [
     "contracts",
@@ -32,7 +32,7 @@
   },
   "license": "AGPLv3",
   "devDependencies": {
-    "@aave/deploy-v3": "^1.21.1-beta.4",
+    "@aave/deploy-v3": "^1.24.1-beta.1",
     "@ethersproject/abi": "^5.1.0",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.11",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -102,7 +102,7 @@ export interface TestEnv {
   rewardsPriceAggregators: tEthereumAddress[];
 }
 
-let hardhatevmSnapshotId: string = '0x1';
+let hardhatevmSnapshotId = '0x1';
 const setHardhatevmSnapshotId = (id: string) => {
   hardhatevmSnapshotId = id;
 };
@@ -183,10 +183,10 @@ export async function initializeMakeSuite() {
   testEnv.helpersContract = await getAaveProtocolDataProvider();
 
   const allTokens = await testEnv.helpersContract.getAllATokens();
-  const aDaiAddress = allTokens.find((aToken) => aToken.symbol === 'aDAI')?.tokenAddress;
-  const aUsdcAddress = allTokens.find((aToken) => aToken.symbol === 'aUSDC')?.tokenAddress;
+  const aDaiAddress = allTokens.find((aToken) => aToken.symbol === 'aTestDAI')?.tokenAddress;
+  const aUsdcAddress = allTokens.find((aToken) => aToken.symbol === 'aTestUSDC')?.tokenAddress;
 
-  const aWEthAddress = allTokens.find((aToken) => aToken.symbol === 'aWETH')?.tokenAddress;
+  const aWEthAddress = allTokens.find((aToken) => aToken.symbol === 'aTestWETH')?.tokenAddress;
 
   const reservesTokens = await testEnv.helpersContract.getAllReservesTokens();
 
@@ -200,9 +200,11 @@ export async function initializeMakeSuite() {
   const wethAddress = reservesTokens.find((token) => token.symbol === 'WETH')?.tokenAddress;
 
   if (!aDaiAddress || !aWEthAddress || !aUsdcAddress) {
+    console.error('Missing AToken address');
     process.exit(1);
   }
   if (!daiAddress || !usdcAddress || !aaveAddress || !wethAddress) {
+    console.error('Missing Reserve address');
     process.exit(1);
   }
 

--- a/test/rewards/misc.spec.ts
+++ b/test/rewards/misc.spec.ts
@@ -27,7 +27,7 @@ makeSuite('AaveIncentivesController misc tests', (testEnv) => {
       artifact.abi,
       artifact.address
     )) as RewardsController;
-    await expect((await rewardsController.EMISSION_MANAGER()).toString()).to.be.equal(
+    await expect((await rewardsController.getEmissionManager()).toString()).to.be.equal(
       peiEmissionManager
     );
   });

--- a/test/rewards/set-emission-manager.spec.ts
+++ b/test/rewards/set-emission-manager.spec.ts
@@ -1,0 +1,63 @@
+import { makeSuite, TestEnv } from '../helpers/make-suite';
+import { ZERO_ADDRESS, waitForTx } from '@aave/deploy-v3';
+
+const { expect } = require('chai');
+
+makeSuite('RewardsController EmissionManager Role', (testEnv: TestEnv) => {
+  it('getEmissionManager should return current admin', async () => {
+    const { rewardsController, deployer } = testEnv;
+
+    const emissionManager = await rewardsController.getEmissionManager();
+
+    expect(emissionManager).to.be.equal(deployer.address);
+  });
+  it('Revert at setEmissionManager if not emissionManager', async () => {
+    const {
+      rewardsController,
+      users: [user1],
+    } = testEnv;
+
+    await expect(
+      rewardsController.connect(user1.signer).setEmissionManager(user1.address)
+    ).to.be.revertedWith('ONLY_EMISSION_MANAGER');
+  });
+  it('Revert at setEmissionManager if emission manager is ZERO_ADDRESS', async () => {
+    const { rewardsController } = testEnv;
+
+    await expect(rewardsController.setEmissionManager(ZERO_ADDRESS)).to.be.revertedWith(
+      'EMISSION_MANAGER_NOT_ZERO'
+    );
+  });
+
+  it('Successfully call setEmissionManager if called by emission manager', async () => {
+    const {
+      rewardsController,
+      users: [user1],
+      deployer,
+    } = testEnv;
+
+    await waitForTx(await rewardsController.setEmissionManager(user1.address));
+
+    const emissionManager = await rewardsController.getEmissionManager();
+
+    expect(emissionManager).to.be.equal(user1.address);
+    expect(emissionManager).to.not.be.equal(deployer.address);
+  });
+
+  it('Successfully call setEmissionManager if called by updated emission manager', async () => {
+    const {
+      rewardsController,
+      users: [user1],
+      deployer,
+    } = testEnv;
+
+    await waitForTx(
+      await rewardsController.connect(user1.signer).setEmissionManager(deployer.address)
+    );
+
+    const emissionManager = await rewardsController.getEmissionManager();
+
+    expect(emissionManager).to.not.be.equal(user1.address);
+    expect(emissionManager).to.be.equal(deployer.address);
+  });
+});


### PR DESCRIPTION
## Changes
- Added _emissionManager internal address and `_setEmissionManager` internal mutator function with event
- Added `getEmissionManager`, `setEmissionManager` external functions
- Add a new address parameter to `initialize` function to set the first emissionManager
- Remove EMISSION_MANAGER immutable constant and references at tests

## Misc
- Add test suite for testing the transfer of ownership of the contract, support latest @aave/deploy-v3 package