### PR TITLE
Add owner constructor parameter to EmissionManager

### DIFF
--- a/contracts/rewards/EmissionManager.sol
+++ b/contracts/rewards/EmissionManager.sol
@@ -30,9 +30,11 @@ contract EmissionManager is Ownable, IEmissionManager {
   /**
    * Constructor.
    * @param controller The address of the RewardsController contract
+   * @param controller The address of the owner of this contract
    */
-  constructor(address controller) {
+  constructor(address controller, address owner) {
     _rewardsController = IRewardsController(controller);
+    transferOwnership(owner);
   }
 
   /// @inheritdoc IEmissionManager

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -241,7 +241,8 @@ export async function initializeMakeSuite() {
   const rewardsController = ((await getIncentivesV2()) as any) as RewardsController;
   testEnv.rewardsController = rewardsController;
   testEnv.emissionManager = await new EmissionManager__factory(deployer.signer).deploy(
-    rewardsController.address
+    rewardsController.address,
+    deployer.address
   );
   testEnv.rewardsVault = rewardsVault;
   testEnv.stakedAave = await getStakeAave();


### PR DESCRIPTION
Add `owner` constructor parameter to EmissionManager contract to support CREATE2 factory deployments