### PR TITLE
feat: use simple flash loan

### DIFF
--- a/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
@@ -49,7 +49,7 @@ abstract contract BaseParaSwapAdapter is FlashLoanSimpleReceiverBase, Ownable {
     uint256 receivedAmount
   );
 
-  constructor(IPoolAddressesProvider addressesProvider) FlashLoanReceiverBase(addressesProvider) {
+  constructor(IPoolAddressesProvider addressesProvider) FlashLoanSimpleReceiverBase(addressesProvider) {
     ORACLE = IPriceOracleGetter(addressesProvider.getPriceOracle());
   }
 

--- a/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.10;
 
 import {DataTypes} from '@aave/core-v3/contracts/protocol/libraries/types/DataTypes.sol';
-import {FlashLoanReceiverBase} from '@aave/core-v3/contracts/flashloan/base/FlashLoanReceiverBase.sol';
+import {FlashLoanSimpleReceiverBase} from '@aave/core-v3/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol';
 import {GPv2SafeERC20} from '@aave/core-v3/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
@@ -17,7 +17,7 @@ import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contrac
  * @notice Utility functions for adapters using ParaSwap
  * @author Jason Raymond Bell
  */
-abstract contract BaseParaSwapAdapter is FlashLoanReceiverBase, Ownable {
+abstract contract BaseParaSwapAdapter is FlashLoanSimpleReceiverBase, Ownable {
   using SafeMath for uint256;
   using GPv2SafeERC20 for IERC20;
   using GPv2SafeERC20 for IERC20Detailed;

--- a/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
+++ b/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
@@ -53,6 +53,7 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
     require(msg.sender == address(POOL), 'CALLER_MUST_BE_POOL');
 
     uint256 flashLoanAmount = amount;
+    uint256 premiumLocal = premium;
     address initiatorLocal = initiator;
     IERC20Detailed assetToSwapFrom = IERC20Detailed(asset);
     (
@@ -72,8 +73,8 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
       swapCalldata,
       augustus,
       permitParams,
-      amount,
-      premium,
+      flashLoanAmount,
+      premiumLocal,
       initiatorLocal,
       assetToSwapFrom,
       assetToSwapTo,

--- a/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
+++ b/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
@@ -30,11 +30,12 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
    * @dev Swaps the received reserve amount from the flash loan into the asset specified in the params.
    * The received funds from the swap are then deposited into the protocol on behalf of the user.
    * The user should give this contract allowance to pull the ATokens in order to withdraw the underlying asset and repay the flash loan.
-   * @param assets Address of the underlying asset to be swapped from
-   * @param amounts Amount of the flash loan i.e. maximum amount to swap
-   * @param premiums Fee of the flash loan
-   * @param initiator Account that initiated the flash loan
-   * @param params Additional variadic field to include extra params. Expected parameters:
+   * @param asset The address of the flash-borrowed asset
+   * @param amount The amount of the flash-borrowed asset
+   * @param premium The fee of the flash-borrowed asset
+   * @param initiator The address of the flashloan initiator
+   * @param params The byte-encoded params passed when initiating the flashloan
+   * @return True if the execution of the operation succeeds, false otherwise
    *   address assetToSwapTo Address of the underlying asset to be swapped to and deposited
    *   uint256 minAmountToReceive Min amount to be received from the swap
    *   uint256 swapAllBalanceOffset Set to offset of fromAmount in Augustus calldata if wanting to swap all balance, otherwise 0
@@ -43,22 +44,17 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
    *   PermitSignature permitParams Struct containing the permit signatures, set to all zeroes if not used
    */
   function executeOperation(
-    address[] calldata assets,
-    uint256[] calldata amounts,
-    uint256[] calldata premiums,
+    address asset,
+    uint256 amount,
+    uint256 premium,
     address initiator,
     bytes calldata params
   ) external override nonReentrant returns (bool) {
     require(msg.sender == address(POOL), 'CALLER_MUST_BE_POOL');
-    require(
-      assets.length == 1 && amounts.length == 1 && premiums.length == 1,
-      'FLASHLOAN_MULTIPLE_ASSETS_NOT_SUPPORTED'
-    );
 
-    uint256 flashLoanAmount = amounts[0];
-    uint256 premium = premiums[0];
+    uint256 flashLoanAmount = amount;
     address initiatorLocal = initiator;
-    IERC20Detailed assetToSwapFrom = IERC20Detailed(assets[0]);
+    IERC20Detailed assetToSwapFrom = IERC20Detailed(asset);
     (
       IERC20Detailed assetToSwapTo,
       uint256 minAmountToReceive,
@@ -76,7 +72,7 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
       swapCalldata,
       augustus,
       permitParams,
-      flashLoanAmount,
+      amount,
       premium,
       initiatorLocal,
       assetToSwapFrom,

--- a/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol
+++ b/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol
@@ -42,11 +42,12 @@ contract ParaSwapRepayAdapter is BaseParaSwapBuyAdapter, ReentrancyGuard {
    * The user should give this contract allowance to pull the ATokens in order to withdraw the underlying asset, swap it
    * and repay the flash loan.
    * Supports only one asset on the flash loan.
-   * @param assets Address of collateral asset(Flash loan asset)
-   * @param amounts Amount of flash loan taken
-   * @param premiums Fee of the flash loan
-   * @param initiator Address of the user
-   * @param params Additional variadic field to include extra params. Expected parameters:
+   * @param asset The address of the flash-borrowed asset
+   * @param amount The amount of the flash-borrowed asset
+   * @param premium The fee of the flash-borrowed asset
+   * @param initiator The address of the flashloan initiator
+   * @param params The byte-encoded params passed when initiating the flashloan
+   * @return True if the execution of the operation succeeds, false otherwise
    *   IERC20Detailed debtAsset Address of the debt asset
    *   uint256 debtAmount Amount of debt to be repaid
    *   uint256 rateMode Rate modes of the debt to be repaid
@@ -58,24 +59,18 @@ contract ParaSwapRepayAdapter is BaseParaSwapBuyAdapter, ReentrancyGuard {
    *   PermitSignature permitParams Struct containing the permit signatures, set to all zeroes if not used
    */
   function executeOperation(
-    address[] calldata assets,
-    uint256[] calldata amounts,
-    uint256[] calldata premiums,
+    address asset,
+    uint256 amount,
+    uint256 premium,
     address initiator,
     bytes calldata params
   ) external override nonReentrant returns (bool) {
     require(msg.sender == address(POOL), 'CALLER_MUST_BE_POOL');
 
-    require(
-      assets.length == 1 && amounts.length == 1 && premiums.length == 1,
-      'FLASHLOAN_MULTIPLE_ASSETS_NOT_SUPPORTED'
-    );
-
-    uint256 collateralAmount = amounts[0];
-    uint256 premium = premiums[0];
+    uint256 collateralAmount = amount;
     address initiatorLocal = initiator;
 
-    IERC20Detailed collateralAsset = IERC20Detailed(assets[0]);
+    IERC20Detailed collateralAsset = IERC20Detailed(asset);
 
     _swapAndRepay(params, premium, initiatorLocal, collateralAsset, collateralAmount);
 

--- a/test/paraswap/paraswapAdapters.liquiditySwap.spec.ts
+++ b/test/paraswap/paraswapAdapters.liquiditySwap.spec.ts
@@ -331,7 +331,7 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           paraswapLiquiditySwapAdapter
             .connect(user)
-            .executeOperation([weth.address], [amountWETHtoSwap], [0], userAddress, params)
+            .executeOperation(weth.address, amountWETHtoSwap, 0, userAddress, params)
         ).to.be.revertedWith('CALLER_MUST_BE_POOL');
       });
 

--- a/test/paraswap/paraswapAdapters.liquiditySwap.spec.ts
+++ b/test/paraswap/paraswapAdapters.liquiditySwap.spec.ts
@@ -162,12 +162,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -260,12 +258,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -417,12 +413,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [usdc.address],
-              [amountUSDCtoSwap],
-              [0],
-              userAddress,
+              usdc.address,
+              amountUSDCtoSwap,
               params,
               0
             )
@@ -501,12 +495,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -592,12 +584,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [usdc.address],
-              [amountUSDCtoSwap],
-              [0],
-              userAddress,
+              usdc.address,
+              amountUSDCtoSwap,
               params,
               0
             )
@@ -663,12 +653,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [bigAmountToSwap],
-              [0],
-              userAddress,
+              weth.address,
+              bigAmountToSwap,
               params,
               0
             )
@@ -772,12 +760,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [bigAmountToSwap],
-              [0],
-              userAddress,
+              weth.address,
+              bigAmountToSwap,
               params,
               0
             )
@@ -855,12 +841,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [smallAmountToSwap],
-              [0],
-              userAddress,
+              weth.address,
+              smallAmountToSwap,
               params,
               0
             )
@@ -917,12 +901,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -988,12 +970,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -1097,12 +1077,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -1198,12 +1176,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap,
               params,
               0
             )
@@ -1282,12 +1258,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [bigAmountToSwap],
-              [0],
-              userAddress,
+              weth.address,
+              bigAmountToSwap,
               params,
               0
             )
@@ -1382,12 +1356,10 @@ makeSuite('ParaSwap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapLiquiditySwapAdapter.address,
-              [weth.address],
-              [bigAmountToSwap],
-              [0],
-              userAddress,
+              weth.address,
+              bigAmountToSwap,
               params,
               0
             )

--- a/test/paraswap/paraswapAdapters.repay.spec.ts
+++ b/test/paraswap/paraswapAdapters.repay.spec.ts
@@ -399,13 +399,7 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           paraswapRepayAdapter
             .connect(user)
-            .executeOperation(
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
-              params
-            )
+            .executeOperation(weth.address, amountWETHtoSwap.toString(), 0, userAddress, params)
         ).to.be.revertedWith('CALLER_MUST_BE_POOL');
       });
 

--- a/test/paraswap/paraswapAdapters.repay.spec.ts
+++ b/test/paraswap/paraswapAdapters.repay.spec.ts
@@ -195,12 +195,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapRepayAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap.toString(),
               params,
               0
             )
@@ -321,12 +319,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapRepayAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap.toString(),
               params,
               0
             )
@@ -472,12 +468,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapRepayAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap.toString(),
               params,
               0
             )
@@ -540,12 +534,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapRepayAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap.toString(),
               params,
               0
             )
@@ -609,12 +601,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapRepayAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap.toString(),
               params,
               0
             )
@@ -698,12 +688,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
         await expect(
           pool
             .connect(user)
-            .flashLoan(
+            .flashLoanSimple(
               paraswapRepayAdapter.address,
-              [weth.address],
-              [amountWETHtoSwap.toString()],
-              [0],
-              userAddress,
+              weth.address,
+              amountWETHtoSwap.toString(),
               params,
               0
             )
@@ -811,12 +799,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
 
         await pool
           .connect(user)
-          .flashLoan(
+          .flashLoanSimple(
             paraswapRepayAdapter.address,
-            [weth.address],
-            [flashLoanAmount.toString()],
-            [0],
-            userAddress,
+            weth.address,
+            flashLoanAmount.toString(),
             params,
             0
           );
@@ -920,12 +906,10 @@ makeSuite('Paraswap adapters', (testEnv: TestEnv) => {
 
         await pool
           .connect(user)
-          .flashLoan(
+          .flashLoanSimple(
             paraswapRepayAdapter.address,
-            [weth.address],
-            [flashLoanAmount.toString()],
-            [0],
-            userAddress,
+            weth.address,
+            flashLoanAmount.toString(),
             params,
             0
           );


### PR DESCRIPTION
This pr alteres the v3 paraswap adapters to use https://github.com/aave/aave-v3-core/blob/master/contracts/flashloan/interfaces/IFlashLoanSimpleReceiver.sol instead of the generic flashLoan interface as it reduces gas consumption in good conditions by ~20k.