### PR TITLE
feat: add getter for current index on rewardsController

### DIFF
--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.10;
 
+import {IScaledBalanceToken} from '@aave/core-v3/contracts/interfaces/IScaledBalanceToken.sol';
 import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {SafeCast} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeCast.sol';
 import {IRewardsDistributor} from './interfaces/IRewardsDistributor.sol';
@@ -54,6 +55,23 @@ abstract contract RewardsDistributor is IRewardsDistributor {
       _assets[asset].rewards[reward].emissionPerSecond,
       _assets[asset].rewards[reward].lastUpdateTimestamp,
       _assets[asset].rewards[reward].distributionEnd
+    );
+  }
+
+  /// @inheritdoc IRewardsDistributor
+  function getAssetIndex(address asset, address reward)
+    external
+    view
+    override
+    returns(uint256, uint256)
+  {
+    RewardsDataTypes.RewardData storage rewardData = _assets[asset].rewards[
+      reward
+    ];
+    return _getAssetIndex(
+      rewardData,
+      IScaledBalanceToken(asset).scaledTotalSupply(),
+      10 ** _assets[asset].decimals
     );
   }
 

--- a/contracts/rewards/interfaces/IRewardsDistributor.sol
+++ b/contracts/rewards/interfaces/IRewardsDistributor.sol
@@ -120,6 +120,21 @@ interface IRewardsDistributor {
     );
 
   /**
+   * @dev Calculates the next value of an specific distribution index, with validations.
+   * @param asset The incentivized asset
+   * @param reward The reward token of the incentivized asset
+   * @return The old index of the asset distribution
+   * @return The new index of the asset distribution
+   **/
+  function getAssetIndex(address asset, address reward)
+    external
+    view
+    returns(
+      uint256,
+      uint256
+    );
+
+  /**
    * @dev Returns the list of available reward token addresses of an incentivized asset
    * @param asset The incentivized asset
    * @return List of rewards addresses of the input asset

--- a/test/rewards/get-rewards-balance.spec.ts
+++ b/test/rewards/get-rewards-balance.spec.ts
@@ -94,6 +94,7 @@ makeSuite('AaveIncentivesController getRewardsBalance tests', (testEnv) => {
 
       const userIndex = await getUserIndex(rewardsController, userAddress, underlyingAsset, reward);
       const assetData = (await getRewardsData(rewardsController, [underlyingAsset], [reward]))[0];
+      const assetIndex = await rewardsController.getAssetIndex(underlyingAsset, reward);
 
       await aDaiMockV2.cleanUserState();
 
@@ -107,6 +108,8 @@ makeSuite('AaveIncentivesController getRewardsBalance tests', (testEnv) => {
       );
       const expectedAccruedRewards = getRewards(stakedByUser, expectedAssetIndex, userIndex);
 
+      expect(assetIndex[0].toString()).to.be.equal(assetData.index.toString());
+      expect(assetIndex[1].toString()).to.be.equal(expectedAssetIndex.toFixed());
       if (shouldAccrue) {
         expect(expectedAccruedRewards).gt('0');
         expect(unclaimedRewards.toString()).to.be.equal(


### PR DESCRIPTION
Other things that would also be nice:
- `claimRewards` always expects `assets[]` but in staticAToken it will always be a single asset. Could make sense to add a method explicitly for one asset.