### PR TITLE
Fix `getUserReward` getter

### DIFF
--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -405,11 +405,12 @@ abstract contract RewardsDistributor is IRewardsDistributor {
     // Add unrealized rewards
     for (uint256 i = 0; i < userAssetBalances.length; i++) {
       if (userAssetBalances[i].userBalance == 0) {
-        continue;
+        unclaimedRewards += _assets[userAssetBalances[i].asset].rewards[reward].usersData[user].accrued;
+      } else {
+        unclaimedRewards +=
+          _getPendingRewards(user, reward, userAssetBalances[i]) +
+          _assets[userAssetBalances[i].asset].rewards[reward].usersData[user].accrued;
       }
-      unclaimedRewards +=
-        _getPendingRewards(user, reward, userAssetBalances[i]) +
-        _assets[userAssetBalances[i].asset].rewards[reward].usersData[user].accrued;
     }
 
     return unclaimedRewards;


### PR DESCRIPTION
## Issue

This aims to fix the `getUserReward` returning 0 when the balance of the user is 0 even though its rewards might not have been claimed. This is clearly not a critical issue but can induce reverts on the integrator side or prevent frontends to display the correct data.

## Solution

Just add the amount already accrued by the user (and not claimed) even the balance is 0.


PS: Let me know if you want that I point this PR to https://github.com/aave/aave-v3-periphery/pull/105 or create an issue instead! @sakulstra @miguelmtzinf 