### PR TITLE
fix: set REVISION of proxy implementations to 1 by default

### DIFF
--- a/contracts/rewards/RewardsController.sol
+++ b/contracts/rewards/RewardsController.sol
@@ -18,7 +18,7 @@ import {IEACAggregatorProxy} from '../misc/interfaces/IEACAggregatorProxy.sol';
 contract RewardsController is RewardsDistributor, VersionedInitializable, IRewardsController {
   using SafeCast for uint256;
 
-  uint256 public constant REVISION = 2;
+  uint256 public constant REVISION = 1;
 
   // This mapping allows whitelisted addresses to claim on behalf of others
   // useful for contracts that hold tokens to be rewarded but don't have any native logic to claim Liquidity Mining rewards

--- a/contracts/treasury/AdminControlledEcosystemReserve.sol
+++ b/contracts/treasury/AdminControlledEcosystemReserve.sol
@@ -24,7 +24,7 @@ abstract contract AdminControlledEcosystemReserve is
 
   address internal _fundsAdmin;
 
-  uint256 public constant REVISION = 4;
+  uint256 public constant REVISION = 1;
 
   /// @inheritdoc IAdminControlledEcosystemReserve
   address public constant ETH_MOCK_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;


### PR DESCRIPTION
For newer deployments, REVISION will be set to `1` by default, even if the contract is changed.

If there is the need to bump the revision to upgrade a proxy, it must be done in a separate repository or branch.