### PR TITLE
fix: move deploy mocks to periphery mocks

### DIFF
--- a/contracts/mocks/WETH9Mock.sol
+++ b/contracts/mocks/WETH9Mock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {WETH9} from "@aave/core-v3/contracts/dependencies/weth/WETH9.sol";
+import {Ownable} from "@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol";
+
+contract WETH9Mock is WETH9, Ownable {
+    constructor(
+        string memory mockName,
+        string memory mockSymbol,
+        address owner
+    ) {
+        name = mockName;
+        symbol = mockSymbol;
+
+        transferOwnership(owner);
+    }
+
+    function mint(address account, uint256 value)
+        public
+        onlyOwner
+        returns (bool)
+    {
+        balanceOf[account] += value;
+        emit Transfer(address(0), account, value);
+        return true;
+    }
+}

--- a/contracts/mocks/testnet-helpers/Faucet.sol
+++ b/contracts/mocks/testnet-helpers/Faucet.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IFaucet} from './IFaucet.sol';
+import {TestnetERC20} from './TestnetERC20.sol';
+import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
+
+/**
+ * @title Faucet
+ * @dev Ownable Faucet Contract
+ */
+contract Faucet is IFaucet, Ownable {
+  // If _permissioned is enabled, then only owner can mint Testnet ERC20 tokens
+  // If disabled, anyone can call mint at the faucet, for PoC environments
+  bool internal _permissioned;
+
+  constructor(address owner, bool permissioned) {
+    require(owner != address(0));
+    transferOwnership(owner);
+
+    _permissioned = permissioned;
+  }
+
+  /**
+   * @dev Function modifier, if _permissioned is enabled then msg.sender is required to be the owner
+   */
+  modifier onlyOwnerIfPermissioned() {
+    if (_permissioned == true) {
+      require(owner() == _msgSender(), 'Ownable: caller is not the owner');
+    }
+    _;
+  }
+
+  /// @inheritdoc IFaucet
+  function mint(
+    address token,
+    address to,
+    uint256 amount
+  ) external override onlyOwnerIfPermissioned returns (uint256) {
+    TestnetERC20(token).mint(to, amount);
+    return amount;
+  }
+
+  /// @inheritdoc IFaucet
+  function setPermissioned(bool permissioned) external override onlyOwner {
+    _permissioned = permissioned;
+  }
+
+  /// @inheritdoc IFaucet
+  function isPermissioned() external view override returns (bool) {
+    return _permissioned;
+  }
+}

--- a/contracts/mocks/testnet-helpers/IFaucet.sol
+++ b/contracts/mocks/testnet-helpers/IFaucet.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+interface IFaucet {
+  /**
+   * @notice Function to mint Testnet tokens to the destination address
+   * @param token The address of the token to perform the mint
+   * @param to The address to send the minted tokens
+   * @param amount The amount of tokens to mint
+   * @return The amount minted
+   **/
+  function mint(
+    address token,
+    address to,
+    uint256 amount
+  ) external returns (uint256);
+
+  /**
+   * @notice Enable or disable the need of authentication to call `mint` function
+   * @param value If true, ask for authentication at `mint` function, if false, disable the authentication
+   */
+  function setPermissioned(bool value) external;
+
+  /**
+   * @notice Getter to determine if permissioned mode is enabled or disabled
+   * @return Returns a boolean, if true the mode is enabled, if false is disabled
+   */
+  function isPermissioned() external view returns (bool);
+}

--- a/contracts/mocks/testnet-helpers/TestnetERC20.sol
+++ b/contracts/mocks/testnet-helpers/TestnetERC20.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
+import {ERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/ERC20.sol';
+import {IERC20WithPermit} from '@aave/core-v3/contracts/interfaces/IERC20WithPermit.sol';
+
+/**
+ * @title TestnetERC20
+ * @dev ERC20 minting logic
+ */
+contract TestnetERC20 is IERC20WithPermit, ERC20, Ownable {
+  bytes public constant EIP712_REVISION = bytes('1');
+  bytes32 internal constant EIP712_DOMAIN =
+    keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)');
+  bytes32 public constant PERMIT_TYPEHASH =
+    keccak256('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)');
+
+  // Map of address nonces (address => nonce)
+  mapping(address => uint256) internal _nonces;
+
+  bytes32 public DOMAIN_SEPARATOR;
+
+  constructor(
+    string memory name,
+    string memory symbol,
+    uint8 decimals,
+    address owner
+  ) ERC20(name, symbol) {
+    uint256 chainId = block.chainid;
+
+    DOMAIN_SEPARATOR = keccak256(
+      abi.encode(
+        EIP712_DOMAIN,
+        keccak256(bytes(name)),
+        keccak256(EIP712_REVISION),
+        chainId,
+        address(this)
+      )
+    );
+    _setupDecimals(decimals);
+    require(owner != address(0));
+    transferOwnership(owner);
+  }
+
+  /// @inheritdoc IERC20WithPermit
+  function permit(
+    address owner,
+    address spender,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external override {
+    require(owner != address(0), 'INVALID_OWNER');
+    //solium-disable-next-line
+    require(block.timestamp <= deadline, 'INVALID_EXPIRATION');
+    uint256 currentValidNonce = _nonces[owner];
+    bytes32 digest = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        DOMAIN_SEPARATOR,
+        keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, currentValidNonce, deadline))
+      )
+    );
+    require(owner == ecrecover(digest, v, r, s), 'INVALID_SIGNATURE');
+    _nonces[owner] = currentValidNonce + 1;
+    _approve(owner, spender, value);
+  }
+
+  /**
+   * @dev Function to mint tokens
+   * @param value The amount of tokens to mint.
+   * @return A boolean that indicates if the operation was successful.
+   */
+  function mint(uint256 value) public virtual onlyOwner returns (bool) {
+    _mint(_msgSender(), value);
+    return true;
+  }
+
+  /**
+   * @dev Function to mint tokens to address
+   * @param account The account to mint tokens.
+   * @param value The amount of tokens to mint.
+   * @return A boolean that indicates if the operation was successful.
+   */
+  function mint(address account, uint256 value) public virtual onlyOwner returns (bool) {
+    _mint(account, value);
+    return true;
+  }
+
+  function nonces(address owner) public view returns (uint256) {
+    return _nonces[owner];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aave/periphery-v3",
-  "version": "1.21.2",
+  "version": "1.21.5",
   "description": "Aave Protocol V3 periphery smart contracts",
   "files": [
     "contracts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aave/periphery-v3",
-  "version": "1.21.5",
+  "version": "1.21.2",
   "description": "Aave Protocol V3 periphery smart contracts",
   "files": [
     "contracts",
@@ -18,7 +18,7 @@
     "hardhat:matic": "hardhat --network matic",
     "compile": "SKIP_LOAD=true hardhat compile",
     "console:fork": "MAINNET_FORK=true hardhat console",
-    "test": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test/__setup.spec.ts ./test/wrapped-token-gateway.spec.ts ./test/rewards/*.spec.ts ./test/rewards/**/*.spec.ts ./test/paraswap/**.spec.ts",
+    "test": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test/__setup.spec.ts test/*spec.ts ./test/wrapped-token-gateway.spec.ts ./test/rewards/*.spec.ts ./test/rewards/**/*.spec.ts ./test/paraswap/**.spec.ts",
     "test-incentives": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test/__setup.spec.ts  ./test/rewards/*.spec.ts ./test/rewards/**/*.spec.ts",
     "test-paraswap": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test/__setup.spec.ts  ./test/paraswap/*.spec.ts",
     "test-strategies": ". ./setup-test-env.sh && TS_NODE_TRANSPILE_ONLY=1 hardhat test test/__setup.spec.ts ./test/rewards/strategies/*.spec.ts",

--- a/test/faucet.spec.ts
+++ b/test/faucet.spec.ts
@@ -1,0 +1,105 @@
+import { getFirstSigner, waitForTx } from '@aave/deploy-v3';
+import { expect } from 'chai';
+import { parseEther } from 'ethers/lib/utils';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { makeSuite, TestEnv } from './helpers/make-suite';
+
+declare let hre: HardhatRuntimeEnvironment;
+
+makeSuite('Faucet', (testEnv: TestEnv) => {
+  const mintAmount = parseEther('100');
+  let faucetOwnable;
+  before(async () => {
+    // Enforce permissioned mode as disabled for deterministic test suite
+
+    const { deployer } = await hre.getNamedAccounts();
+    const factory = await hre.ethers.getContractFactory('Faucet');
+
+    faucetOwnable = await factory.deploy(deployer, false);
+
+    await waitForTx(await faucetOwnable.setPermissioned(false));
+  });
+  describe('Permissioned mode: disabled', () => {
+    before(async () => {
+      // Enforce permissioned mode as disabled for deterministic test suite
+      await waitForTx(await faucetOwnable.setPermissioned(false));
+    });
+    it('Mint can be called by anyone', async () => {
+      const {
+        users: [user],
+        dai,
+      } = testEnv;
+
+      await waitForTx(
+        await faucetOwnable.connect(user.signer).mint(dai.address, user.address, mintAmount)
+      );
+
+      await expect(await dai.balanceOf(user.address)).eq(mintAmount);
+    });
+
+    it('Getter isPermissioned should return false', async () => {
+      await expect(await faucetOwnable.isPermissioned()).is.equal(false);
+    });
+  });
+
+  describe('Permissioned mode: enabled', () => {
+    before(async () => {
+      // Enforce permissioned mode as enabled for deterministic test suite
+      await waitForTx(await faucetOwnable.setPermissioned(true));
+    });
+    it('Mint function should revert if caller not owner', async () => {
+      const {
+        users: [, , user],
+        dai,
+      } = testEnv;
+
+      await expect(
+        faucetOwnable.connect(user.signer).mint(dai.address, user.address, mintAmount)
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('Mint function can only be called by owner', async () => {
+      const {
+        users: [, , , user],
+        dai,
+        deployer,
+      } = testEnv;
+
+      await waitForTx(
+        await faucetOwnable.connect(deployer.signer).mint(dai.address, user.address, mintAmount)
+      );
+
+      await expect(await dai.balanceOf(user.address)).eq(mintAmount);
+    });
+
+    it('Getter isPermissioned should return true', async () => {
+      await expect(await faucetOwnable.isPermissioned()).is.equal(true);
+    });
+  });
+
+  it('Function setPermissioned should revert if caller not owner', async () => {
+    const {
+      users: [, , user],
+    } = testEnv;
+
+    await expect(faucetOwnable.connect(user.signer).setPermissioned(false)).to.be.revertedWith(
+      'Ownable: caller is not the owner'
+    );
+  });
+
+  it('Function setPermissioned can only be called by owner: false input', async () => {
+    const { deployer } = testEnv;
+
+    await waitForTx(await faucetOwnable.connect(deployer.signer).setPermissioned(false));
+
+    expect(await faucetOwnable.isPermissioned()).equal(false);
+  });
+
+  it('Function setPermissioned can only be called by owner: true input', async () => {
+    const { deployer } = testEnv;
+
+    await waitForTx(await faucetOwnable.connect(deployer.signer).setPermissioned(true));
+
+    expect(await faucetOwnable.isPermissioned()).equal(true);
+  });
+});


### PR DESCRIPTION
- Move Faucet, TestnetToken and WETH9Mock contracts to `@aave/periphery-v3`
- Move Faucet tests