### PR TITLE
fix: publish all artifacts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Aave Protocol V3 periphery smart contracts",
   "files": [
     "contracts",
-    "artifacts/contracts"
+    "artifacts"
   ],
   "scripts": {
     "run-env": "npm i && tail -f /dev/null",


### PR DESCRIPTION
### Rationale
If you import @aave/periphery artifacts to deploy with `hardhat-deploy`, it will not be able to detect the solidity input metadata due `artifacts/build-info` is not exposed. This prevents to use automated verification tools to verify periphery contracts at Etherscan.

Via publishing all the content of the artifacts directory, including the build-info, it will improve the DX of developers that wants to use the artifacts without the need of compiling the contracts.