### PR TITLE
fix: SafeERC20

### DIFF
--- a/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
@@ -5,12 +5,13 @@ import {DataTypes} from '@aave/core-v3/contracts/protocol/libraries/types/DataTy
 import {FlashLoanSimpleReceiverBase} from '@aave/core-v3/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol';
 import {GPv2SafeERC20} from '@aave/core-v3/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
-import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {IERC20WithPermit} from '@aave/core-v3/contracts/interfaces/IERC20WithPermit.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
 import {IPriceOracleGetter} from '@aave/core-v3/contracts/interfaces/IPriceOracleGetter.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';
 import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
+
+import {IERC20Metadata} from '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
 /**
  * @title BaseParaSwapAdapter
@@ -20,7 +21,7 @@ import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contrac
 abstract contract BaseParaSwapAdapter is FlashLoanSimpleReceiverBase, Ownable {
   using SafeMath for uint256;
   using GPv2SafeERC20 for IERC20;
-  using GPv2SafeERC20 for IERC20Detailed;
+  using GPv2SafeERC20 for IERC20Metadata;
   using GPv2SafeERC20 for IERC20WithPermit;
 
   struct PermitSignature {
@@ -66,7 +67,7 @@ abstract contract BaseParaSwapAdapter is FlashLoanSimpleReceiverBase, Ownable {
    * @dev Get the decimals of an asset
    * @return number of decimals of the asset
    */
-  function _getDecimals(IERC20Detailed asset) internal view returns (uint8) {
+  function _getDecimals(IERC20Metadata asset) internal view returns (uint8) {
     uint8 decimals = asset.decimals();
     // Ensure 10**decimals won't overflow a uint256
     require(decimals <= 77, 'TOO_MANY_DECIMALS_ON_TOKEN');

--- a/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
@@ -9,6 +9,8 @@ import {IParaSwapAugustus} from './interfaces/IParaSwapAugustus.sol';
 import {IParaSwapAugustusRegistry} from './interfaces/IParaSwapAugustusRegistry.sol';
 import {BaseParaSwapAdapter} from './BaseParaSwapAdapter.sol';
 
+import {IERC20Metadata} from '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
+
 /**
  * @title BaseParaSwapBuyAdapter
  * @notice Implements the logic for buying tokens on ParaSwap
@@ -40,8 +42,8 @@ abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
   function _buyOnParaSwap(
     uint256 toAmountOffset,
     bytes memory paraswapData,
-    IERC20Detailed assetToSwapFrom,
-    IERC20Detailed assetToSwapTo,
+    IERC20Metadata assetToSwapFrom,
+    IERC20Metadata assetToSwapTo,
     uint256 maxAmountToSwap,
     uint256 amountToReceive
   ) internal returns (uint256 amountSold) {

--- a/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
@@ -9,6 +9,9 @@ import {IParaSwapAugustus} from './interfaces/IParaSwapAugustus.sol';
 import {IParaSwapAugustusRegistry} from './interfaces/IParaSwapAugustusRegistry.sol';
 import {BaseParaSwapAdapter} from './BaseParaSwapAdapter.sol';
 
+import {IERC20Metadata} from '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+
 /**
  * @title BaseParaSwapSellAdapter
  * @notice Implements the logic for selling tokens on ParaSwap
@@ -43,8 +46,8 @@ abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
     uint256 fromAmountOffset,
     bytes memory swapCalldata,
     IParaSwapAugustus augustus,
-    IERC20Detailed assetToSwapFrom,
-    IERC20Detailed assetToSwapTo,
+    IERC20Metadata assetToSwapFrom,
+    IERC20Metadata assetToSwapTo,
     uint256 amountToSwap,
     uint256 minAmountToReceive
   ) internal returns (uint256 amountReceived) {
@@ -70,8 +73,8 @@ abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
     uint256 balanceBeforeAssetTo = assetToSwapTo.balanceOf(address(this));
 
     address tokenTransferProxy = augustus.getTokenTransferProxy();
-    assetToSwapFrom.approve(tokenTransferProxy, 0);
-    assetToSwapFrom.approve(tokenTransferProxy, amountToSwap);
+    SafeERC20.forceApprove(assetToSwapFrom, tokenTransferProxy, 0);
+    SafeERC20.forceApprove(assetToSwapFrom, tokenTransferProxy, amountToSwap);
 
     if (fromAmountOffset != 0) {
       // Ensure 256 bit (32 bytes) fromAmount value is within bounds of the

--- a/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
+++ b/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.10;
 
-// import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {IERC20WithPermit} from '@aave/core-v3/contracts/interfaces/IERC20WithPermit.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.4.0",
       "license": "AGPLv3",
       "dependencies": {
-        "@aave/core-v3": "1.17.0"
+        "@aave/core-v3": "1.17.0",
+        "@openzeppelin/contracts": "4.9.2"
       },
       "devDependencies": {
         "@aave/deploy-v3": "1.50.1",
@@ -2078,6 +2079,11 @@
         "ethers": "^5.0.0",
         "hardhat": "^2.0.0"
       }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.2.tgz",
+      "integrity": "sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg=="
     },
     "node_modules/@resolver-engine/core": {
       "version": "0.3.3",
@@ -26801,6 +26807,11 @@
         "@types/sinon-chai": "^3.2.3",
         "@types/web3": "1.0.19"
       }
+    },
+    "@openzeppelin/contracts": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.2.tgz",
+      "integrity": "sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg=="
     },
     "@resolver-engine/core": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "url": "git://github.com/aave/aave-v3-periphery"
   },
   "dependencies": {
-    "@aave/core-v3": "1.17.0"
+    "@aave/core-v3": "1.17.0",
+    "@openzeppelin/contracts": "4.9.2"
   }
 }


### PR DESCRIPTION
Uses `SafeERC20` for approvals in paraswap adapters. 

Due to some conflicts in inherited interface types, I had to replace `IERC20Detailed` with `IERC20MetaData` in order to use `SafeERC20`, but comparing the two, it seemed like they should be interchangeable. I also left in `GPv2SafeERC20` for now, but could potentially remove that now.