### PR TITLE
fix: use SafeERC20

### DIFF
--- a/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.10;
 
 import {DataTypes} from '@aave/core-v3/contracts/protocol/libraries/types/DataTypes.sol';
 import {FlashLoanSimpleReceiverBase} from '@aave/core-v3/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol';
-import {GPv2SafeERC20} from '@aave/core-v3/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {IERC20WithPermit} from '@aave/core-v3/contracts/interfaces/IERC20WithPermit.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
 import {IPriceOracleGetter} from '@aave/core-v3/contracts/interfaces/IPriceOracleGetter.sol';
+import {SafeERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeERC20.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';
 import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
 
@@ -19,9 +19,9 @@ import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contrac
  */
 abstract contract BaseParaSwapAdapter is FlashLoanSimpleReceiverBase, Ownable {
   using SafeMath for uint256;
-  using GPv2SafeERC20 for IERC20;
-  using GPv2SafeERC20 for IERC20Detailed;
-  using GPv2SafeERC20 for IERC20WithPermit;
+  using SafeERC20 for IERC20;
+  using SafeERC20 for IERC20Detailed;
+  using SafeERC20 for IERC20WithPermit;
 
   struct PermitSignature {
     uint256 amount;

--- a/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapAdapter.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.10;
 
 import {DataTypes} from '@aave/core-v3/contracts/protocol/libraries/types/DataTypes.sol';
 import {FlashLoanSimpleReceiverBase} from '@aave/core-v3/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol';
+import {GPv2SafeERC20} from '@aave/core-v3/contracts/dependencies/gnosis/contracts/GPv2SafeERC20.sol';
 import {IERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol';
 import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {IERC20WithPermit} from '@aave/core-v3/contracts/interfaces/IERC20WithPermit.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
 import {IPriceOracleGetter} from '@aave/core-v3/contracts/interfaces/IPriceOracleGetter.sol';
-import {SafeERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeERC20.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';
 import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/Ownable.sol';
 
@@ -19,9 +19,9 @@ import {Ownable} from '@aave/core-v3/contracts/dependencies/openzeppelin/contrac
  */
 abstract contract BaseParaSwapAdapter is FlashLoanSimpleReceiverBase, Ownable {
   using SafeMath for uint256;
-  using SafeERC20 for IERC20;
-  using SafeERC20 for IERC20Detailed;
-  using SafeERC20 for IERC20WithPermit;
+  using GPv2SafeERC20 for IERC20;
+  using GPv2SafeERC20 for IERC20Detailed;
+  using GPv2SafeERC20 for IERC20WithPermit;
 
   struct PermitSignature {
     uint256 amount;

--- a/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapBuyAdapter.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.10;
 
+import {SafeERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeERC20.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';
 import {PercentageMath} from '@aave/core-v3/contracts/protocol/libraries/math/PercentageMath.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
@@ -16,6 +17,7 @@ import {BaseParaSwapAdapter} from './BaseParaSwapAdapter.sol';
 abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
   using PercentageMath for uint256;
   using SafeMath for uint256;
+  using SafeERC20 for IERC20Detailed;
 
   IParaSwapAugustusRegistry public immutable AUGUSTUS_REGISTRY;
 
@@ -72,8 +74,8 @@ abstract contract BaseParaSwapBuyAdapter is BaseParaSwapAdapter {
     uint256 balanceBeforeAssetTo = assetToSwapTo.balanceOf(address(this));
 
     address tokenTransferProxy = augustus.getTokenTransferProxy();
-    assetToSwapFrom.approve(tokenTransferProxy, 0);
-    assetToSwapFrom.approve(tokenTransferProxy, maxAmountToSwap);
+    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
+    assetToSwapFrom.safeApprove(tokenTransferProxy, maxAmountToSwap);
 
     if (toAmountOffset != 0) {
       // Ensure 256 bit (32 bytes) toAmountOffset value is within bounds of the

--- a/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
+++ b/contracts/adapters/paraswap/BaseParaSwapSellAdapter.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.10;
 
+import {SafeERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeERC20.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';
 import {PercentageMath} from '@aave/core-v3/contracts/protocol/libraries/math/PercentageMath.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
@@ -17,6 +18,7 @@ import {BaseParaSwapAdapter} from './BaseParaSwapAdapter.sol';
 abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
   using PercentageMath for uint256;
   using SafeMath for uint256;
+  using SafeERC20 for IERC20Detailed;
 
   IParaSwapAugustusRegistry public immutable AUGUSTUS_REGISTRY;
 
@@ -70,8 +72,8 @@ abstract contract BaseParaSwapSellAdapter is BaseParaSwapAdapter {
     uint256 balanceBeforeAssetTo = assetToSwapTo.balanceOf(address(this));
 
     address tokenTransferProxy = augustus.getTokenTransferProxy();
-    assetToSwapFrom.approve(tokenTransferProxy, 0);
-    assetToSwapFrom.approve(tokenTransferProxy, amountToSwap);
+    assetToSwapFrom.safeApprove(tokenTransferProxy, 0);
+    assetToSwapFrom.safeApprove(tokenTransferProxy, amountToSwap);
 
     if (fromAmountOffset != 0) {
       // Ensure 256 bit (32 bytes) fromAmount value is within bounds of the

--- a/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
+++ b/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.10;
 import {IERC20Detailed} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
 import {IERC20WithPermit} from '@aave/core-v3/contracts/interfaces/IERC20WithPermit.sol';
 import {IPoolAddressesProvider} from '@aave/core-v3/contracts/interfaces/IPoolAddressesProvider.sol';
+import {SafeERC20} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeERC20.sol';
 import {SafeMath} from '@aave/core-v3/contracts/dependencies/openzeppelin/contracts/SafeMath.sol';
 import {BaseParaSwapSellAdapter} from './BaseParaSwapSellAdapter.sol';
 import {IParaSwapAugustusRegistry} from './interfaces/IParaSwapAugustusRegistry.sol';
@@ -17,6 +18,7 @@ import {ReentrancyGuard} from '../../dependencies/openzeppelin/ReentrancyGuard.s
  */
 contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuard {
   using SafeMath for uint256;
+  using SafeERC20 for IERC20Detailed;
 
   constructor(
     IPoolAddressesProvider addressesProvider,
@@ -135,8 +137,8 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
       minAmountToReceive
     );
 
-    assetToSwapTo.approve(address(POOL), 0);
-    assetToSwapTo.approve(address(POOL), amountReceived);
+    assetToSwapTo.safeApprove(address(POOL), 0);
+    assetToSwapTo.safeApprove(address(POOL), amountReceived);
     POOL.deposit(address(assetToSwapTo), amountReceived, msg.sender, 0);
   }
 
@@ -189,8 +191,8 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
       minAmountToReceive
     );
 
-    assetToSwapTo.approve(address(POOL), 0);
-    assetToSwapTo.approve(address(POOL), amountReceived);
+    assetToSwapTo.safeApprove(address(POOL), 0);
+    assetToSwapTo.safeApprove(address(POOL), amountReceived);
     POOL.deposit(address(assetToSwapTo), amountReceived, initiator, 0);
 
     _pullATokenAndWithdraw(
@@ -202,7 +204,7 @@ contract ParaSwapLiquiditySwapAdapter is BaseParaSwapSellAdapter, ReentrancyGuar
     );
 
     // Repay flash loan
-    assetToSwapFrom.approve(address(POOL), 0);
-    assetToSwapFrom.approve(address(POOL), flashLoanAmount.add(premium));
+    assetToSwapFrom.safeApprove(address(POOL), 0);
+    assetToSwapFrom.safeApprove(address(POOL), flashLoanAmount.add(premium));
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.0",
       "license": "AGPLv3",
       "dependencies": {
-        "@aave/core-v3": "1.17.0"
+        "@aave/core-v3": "1.19.0"
       },
       "devDependencies": {
         "@aave/deploy-v3": "1.50.1",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@aave/core-v3": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.0.tgz",
-      "integrity": "sha512-vcGEPcoDILN1ZBXeqRsK+TXp1VGDvYxaiq/ZJ2XT2/134PbmXAlNlZIrGw1b4WIwIG4egNu8OW6whyWjp/aLlA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.19.0.tgz",
+      "integrity": "sha512-9Uw3FY8TFB2SWnKXtKT7b+HDt+ZV6qfXvuU/9gcNx0NiEH0Qz2IvHleHhLVhXllmkJPMAb/F324+riyvEcDWFw==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -25368,9 +25368,9 @@
   },
   "dependencies": {
     "@aave/core-v3": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.0.tgz",
-      "integrity": "sha512-vcGEPcoDILN1ZBXeqRsK+TXp1VGDvYxaiq/ZJ2XT2/134PbmXAlNlZIrGw1b4WIwIG4egNu8OW6whyWjp/aLlA=="
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.19.0.tgz",
+      "integrity": "sha512-9Uw3FY8TFB2SWnKXtKT7b+HDt+ZV6qfXvuU/9gcNx0NiEH0Qz2IvHleHhLVhXllmkJPMAb/F324+riyvEcDWFw=="
     },
     "@aave/deploy-v3": {
       "version": "1.50.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "url": "git://github.com/aave/aave-v3-periphery"
   },
   "dependencies": {
-    "@aave/core-v3": "1.17.0"
+    "@aave/core-v3": "1.19.0"
   }
 }


### PR DESCRIPTION
- Use v1.19.0 of `@aave/core-v3`, which has `SafeERC20` dependency
- Changed paraswap adapter contracts to use `safeApprove` instead of `approve`